### PR TITLE
Use Debian base image to avoid runtime segfaults from Alpine

### DIFF
--- a/radvd/Dockerfile
+++ b/radvd/Dockerfile
@@ -1,7 +1,0 @@
-FROM alpine:3.14
-RUN apk update && apk add tini bash ip6tables networkmanager radvd
-WORKDIR /usr/src/app
-COPY start.sh /usr/src/app/start.sh
-
-ENTRYPOINT ["/sbin/tini", "--"]
-CMD ["/usr/src/app/start.sh"]

--- a/radvd/Dockerfile.template
+++ b/radvd/Dockerfile.template
@@ -1,0 +1,7 @@
+FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:bullseye
+RUN install_packages tini bash iptables network-manager radvd
+WORKDIR /usr/src/app
+COPY start.sh /usr/src/app/start.sh
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["/usr/src/app/start.sh"]


### PR DESCRIPTION
Uses a balenalib Debian base image to avoid segfaults at runtime, which include `error 4 in ld-musl-x86_64.so.` The strong suspicion is that the error is Alpine/musl specific. Indeed there is a similar [issue](https://github.com/radvd-project/radvd/issues/158) in the radvd repository.

The downside is that this image is 207 MB vs. 37 MB for the Alpine image.