### PR TITLE
Use Debian base image to avoid runtime segfaults from Alpine

### DIFF
--- a/router/Dockerfile
+++ b/router/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:3.14
-RUN apk update && apk add tini bash ip6tables networkmanager radvd dnsmasq openvpn
+FROM debian:bullseye-slim
+RUN apt-get update && apt-get install -y tini bash iptables network-manager radvd dnsmasq openvpn
 WORKDIR /usr/src/app
 COPY openvpn-client.conf /etc/openvpn/client.conf
 COPY start.sh /usr/src/app/start.sh
 
-ENTRYPOINT ["/sbin/tini", "--"]
+ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["/usr/src/app/start.sh"]


### PR DESCRIPTION
Uses a balenalib Debian base image to avoid segfaults at runtime, which include error 4 in ld-musl-x86_64.so. The strong suspicion is that the error is Alpine/musl specific. Indeed there is a similar issue in the radvd repository.

The downside is that this image is 218 MB vs. 37 MB for the Alpine image.

I have tested with Hurricane Electric 6in4, but _**not**_ tested with 6project.org / OpenVPN.
